### PR TITLE
binutils/riscv: Real register names in DWARF output

### DIFF
--- a/binutils/ChangeLog.RISCV
+++ b/binutils/ChangeLog.RISCV
@@ -1,0 +1,9 @@
+2017-08-09  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* dwarf.c (dwarf_regnames_riscv): New global.
+	(init_dwarf_regnames_riscv): New function.
+	(init_dwarf_regnames): Call init_dwarf_regnames_riscv when
+	appropriate.
+	* dwarf.h (init_dwarf_regnames_riscv): Declare.
+	* objdump.c (dump_dwarf): Call init_dwarf_regnames_riscv when
+	appropriate.

--- a/binutils/dwarf.c
+++ b/binutils/dwarf.c
@@ -6511,6 +6511,26 @@ init_dwarf_regnames_s390 (void)
   dwarf_regnames_count = ARRAY_SIZE (dwarf_regnames_s390);
 }
 
+static const char *const dwarf_regnames_riscv[] =
+{
+  "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",
+  "x8",  "x9",  "x10", "x11", "x12", "x13", "x14", "x15",
+  "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23",
+  "x24", "x25", "x26", "x27", "x28", "x29", "x30", "x31",
+  "pc",
+  "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
+  "f8",  "f9",  "f10", "f11", "f12", "f13", "f14", "f15",
+  "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+  "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31",
+};
+
+void
+init_dwarf_regnames_riscv (void)
+{
+  dwarf_regnames = dwarf_regnames_riscv;
+  dwarf_regnames_count = ARRAY_SIZE (dwarf_regnames_riscv);
+}
+
 void
 init_dwarf_regnames (unsigned int e_machine)
 {
@@ -6536,6 +6556,10 @@ init_dwarf_regnames (unsigned int e_machine)
 
     case EM_S390:
       init_dwarf_regnames_s390 ();
+      break;
+
+    case EM_RISCV:
+      init_dwarf_regnames_riscv ();
       break;
 
     default:

--- a/binutils/dwarf.h
+++ b/binutils/dwarf.h
@@ -213,6 +213,7 @@ extern void init_dwarf_regnames_iamcu (void);
 extern void init_dwarf_regnames_x86_64 (void);
 extern void init_dwarf_regnames_aarch64 (void);
 extern void init_dwarf_regnames_s390 (void);
+extern void init_dwarf_regnames_riscv (void);
 
 extern int load_debug_section (enum dwarf_section_display_enum, void *);
 extern void free_debug_section (enum dwarf_section_display_enum);

--- a/binutils/objdump.c
+++ b/binutils/objdump.c
@@ -2688,6 +2688,10 @@ dump_dwarf (bfd *abfd)
       init_dwarf_regnames_s390 ();
       break;
 
+    case bfd_arch_riscv:
+      init_dwarf_regnames_riscv ();
+      break;
+
     default:
       break;
     }


### PR DESCRIPTION
Use real register names in the DWARF output of objdump and readelf.

ChangeLog:

	* dwarf.c (dwarf_regnames_riscv): New global.
	(init_dwarf_regnames_riscv): New function.
	(init_dwarf_regnames): Call init_dwarf_regnames_riscv when
	appropriate.
	* dwarf.h (init_dwarf_regnames_riscv): Declare.
	* objdump.c (dump_dwarf): Call init_dwarf_regnames_riscv when
	appropriate.